### PR TITLE
Fix Uthmani script number reverse.

### DIFF
--- a/app/src/main/java/com/quranapp/android/reader_managers/ReaderVerseDecorator.kt
+++ b/app/src/main/java/com/quranapp/android/reader_managers/ReaderVerseDecorator.kt
@@ -97,7 +97,7 @@ class ReaderVerseDecorator(private val ctx: Context) {
             verse,
             if (isKFQPC) fontsArabicKFQPC[verse.pageNo] ?: Typeface.DEFAULT else fontQuranText,
             verseTextSize,
-            savedScript == QuranScriptUtils.SCRIPT_UTHMANI
+            savedScript == QuranScriptUtils.SCRIPT_DEFAULT
         )
     }
 
@@ -110,7 +110,7 @@ class ReaderVerseDecorator(private val ctx: Context) {
             txtColor,
             verse,
             if (isKFQPCScript()) fontsArabicKFQPC[verse.pageNo] else fontQuranText,
-            savedScript == QuranScriptUtils.SCRIPT_UTHMANI,
+            savedScript == QuranScriptUtils.SCRIPT_DEFAULT,
             onClick
         )
 


### PR DESCRIPTION
This PR is a small fix for arabic numbers reversed when user change default Quran script to uthmani hafs script.

Before:

![Screenshot_20230404_080639_QuranApp](https://user-images.githubusercontent.com/3160786/229701186-a3dc7bc9-3892-4d22-8d1e-909ef6929996.png)

After:

![Screenshot_20230404_080700_QuranApp Debug](https://user-images.githubusercontent.com/3160786/229701240-0d3c8daa-0882-416a-8b7a-2b7145a3b576.png)


Before:

![Screenshot_20230404_080938_QuranApp](https://user-images.githubusercontent.com/3160786/229701457-2aa214b4-36cd-42f2-b03c-dda5ea7817a7.png)

After:

![Screenshot_20230404_080829_QuranApp Debug](https://user-images.githubusercontent.com/3160786/229701489-f06d747b-7fc6-4c32-bd1b-bbdc63708d25.png)
