### PR TITLE
Fix #577: Prevent crash when switching to split screen mode

### DIFF
--- a/app/src/main/java/com/quranapp/android/activities/ActivityReader.java
+++ b/app/src/main/java/com/quranapp/android/activities/ActivityReader.java
@@ -1383,6 +1383,10 @@ public class ActivityReader extends ReaderPossessingActivity implements SmoothAu
 
     private void saveReaderState(boolean saveToHistory) {
         // Get first & last visible item positions (both could be same)
+        if (mLayoutManager == null) {
+            return;
+        }
+
         int firstPos = mLayoutManager.findFirstVisibleItemPosition();
         int lastPos = mLayoutManager.findLastVisibleItemPosition();
 


### PR DESCRIPTION
## Description

Fixes #577 - App crash when switching to split screen mode

## Changes
- Add null check for mLayoutManager in saveReaderState() method
- Prevents NullPointerException during split screen transitions
- Layout manager can become null during view destruction in configuration changes

## Root Cause
When switching to split screen, onPause() is called during view destruction. The mLayoutManager can become null before saveReaderState() attempts to access it, causing a crash.

## Solution
Check if mLayoutManager is null before accessing its methods. If null, the method returns early without attempting to save state.