### PR TITLE
New Feature: Arabic Text Visibility Toggle

### DIFF
--- a/app/src/main/java/com/quranapp/android/activities/ActivityReader.java
+++ b/app/src/main/java/com/quranapp/android/activities/ActivityReader.java
@@ -1265,6 +1265,7 @@ public class ActivityReader extends ReaderPossessingActivity implements SmoothAu
         boolean translTextSizeChanged = SPReader.getSavedTextSizeMultTransl(this) != mReaderParams.translTextSizeMult;
         boolean readerStyleChanged = mReaderParams.getReaderStyle() != SPReader.getSavedReaderStyle(this);
         boolean scriptChanged = !Objects.equals(SPReader.getSavedScript(this), mReaderParams.readerScript);
+        boolean arabicTextVisibilityChanged = SPReader.getArabicTextEnabled(this) != mReaderParams.arabicTextEnabled;
 
         tryReciterChange();
 
@@ -1301,7 +1302,7 @@ public class ActivityReader extends ReaderPossessingActivity implements SmoothAu
         if (readerStyleChanged) {
             onReaderStyleChanged(arTextSizeChanged, translTextSizeChanged);
         } else {
-            if (mReaderParams.getReaderStyle() != READER_STYLE_PAGE && translChanged) {
+            if (mReaderParams.getReaderStyle() != READER_STYLE_PAGE && (translChanged || arabicTextVisibilityChanged)) {
                 onTranslChanged(arTextSizeChanged, translTextSizeChanged);
             } else {
                 applySettingsChanges(arTextSizeChanged, translTextSizeChanged, false);

--- a/app/src/main/java/com/quranapp/android/compose/screens/settings/TranslationSelectionScreen.kt
+++ b/app/src/main/java/com/quranapp/android/compose/screens/settings/TranslationSelectionScreen.kt
@@ -40,13 +40,16 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.MaterialTheme.colorScheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.VerticalDivider
 import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -65,8 +68,10 @@ import com.quranapp.android.components.transls.TranslModel
 import com.quranapp.android.components.transls.TranslationGroupModel
 import com.quranapp.android.compose.components.ErrorMessageCard
 import com.quranapp.android.utils.reader.TranslUtils
+import com.quranapp.android.utils.sharedPrefs.SPReader
 import com.quranapp.android.utils.univ.MessageUtils
 import com.quranapp.android.utils.univ.StringUtils
+import com.quranapp.android.views.reader.updateAllVotdWidgets
 import com.quranapp.android.viewModels.TranslationEvent
 import com.quranapp.android.viewModels.TranslationUiState
 import com.quranapp.android.viewModels.TranslationViewModel
@@ -152,6 +157,10 @@ private fun Content(
         contentPadding = PaddingValues(start = 16.dp, end = 16.dp, top = 16.dp, bottom = 48.dp),
         verticalArrangement = Arrangement.spacedBy(10.dp)
     ) {
+        item {
+            ArabicTextToggle()
+        }
+
         items(groups, key = { it.langCode }) { group ->
             LanguageGroupCard(
                 group = group,
@@ -160,6 +169,61 @@ private fun Content(
         }
 
         item { Spacer(modifier = Modifier.height(60.dp)) }
+    }
+}
+
+@Composable
+private fun ArabicTextToggle() {
+    val context = LocalContext.current
+    var isEnabled by remember { mutableStateOf(SPReader.getArabicTextEnabled(context)) }
+
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .border(
+                width = 1.dp,
+                color = colorScheme.outlineVariant.copy(alpha = 0.4f),
+                shape = RoundedCornerShape(12.dp)
+            ),
+        shape = RoundedCornerShape(12.dp),
+        colors = CardDefaults.cardColors(containerColor = colorScheme.surfaceContainerLow),
+        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable {
+                    isEnabled = !isEnabled
+                    SPReader.setArabicTextEnabled(context, isEnabled)
+                    updateAllVotdWidgets(context)
+                }
+                .padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = stringResource(R.string.titleArabicTextToggle),
+                    style = MaterialTheme.typography.titleMedium,
+                    color = colorScheme.onSurface,
+                    fontWeight = FontWeight.SemiBold
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = stringResource(R.string.msgArabicTextToggle),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = colorScheme.onSurfaceVariant
+                )
+            }
+            Spacer(modifier = Modifier.width(16.dp))
+            Switch(
+                checked = isEnabled,
+                onCheckedChange = {
+                    isEnabled = it
+                    SPReader.setArabicTextEnabled(context, it)
+                    updateAllVotdWidgets(context)
+                }
+            )
+        }
     }
 }
 

--- a/app/src/main/java/com/quranapp/android/reader_managers/ReaderParams.java
+++ b/app/src/main/java/com/quranapp/android/reader_managers/ReaderParams.java
@@ -43,6 +43,7 @@ public class ReaderParams {
     public String readerScript;
     public float arTextSizeMult;
     public float translTextSizeMult;
+    public boolean arabicTextEnabled;
     public Chapter currChapter;
     public int currJuzNo;
     public Pair<Integer, Integer> verseRange;
@@ -105,6 +106,7 @@ public class ReaderParams {
     public void resetTextSizesStates() {
         arTextSizeMult = SPReader.getSavedTextSizeMultArabic(mActivity);
         translTextSizeMult = SPReader.getSavedTextSizeMultTransl(mActivity);
+        arabicTextEnabled = SPReader.getArabicTextEnabled(mActivity);
     }
 
 


### PR DESCRIPTION
## Arabic Text Visibility Toggle
Adds a new setting in the Translations screen that allows users to show or hide the Arabic verse text throughout the reader. This enables a "Clean Translation" mode, perfect for users who want to focus strictly on reading the translation or tafsir without the Arabic script visible.

**Technical Implementation:**

- Added a toggle button in the Compose-based TranslationSelectionScreen.
- Instrumented ReaderParams to manage the visibility state.
- Updated ActivityReader to dynamically refresh when the toggle is changed, ensuring a seamless user experience without requiring an app restart.